### PR TITLE
Temporarily downgrades ion-python dependency to 0.8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,6 @@ jobs:
         run: python3 -m venv ./venv && . venv/bin/activate
 
       - run: pip install --upgrade setuptools
-      - run: pip install -r requirements.txt
+      - run: pip install --use-pep517 -r requirements.txt
       - run: pip install .
       - run: python amazon/iontest/ion_test_driver.py --help

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ py>=1.10.0
 pytest>=6.1.1
 pytest-runner>=2.8
 six>=1.10.0
-amazon.ion>=0.8.0
+amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-py==1.10.0
-pytest==6.2.4
-pytest-runner==5.3.1
+py>=1.10.0
+pytest>=6.2.4
+pytest-runner>=5.3.1
 amazon.ion==0.8.0
-docopt==0.6.2
+docopt>=0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-py==1.10.0
+py>=1.10.0
 pytest==6.1.1
 pytest-runner==2.8
 amazon.ion==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 py==1.10.0
 pytest==6.1.1
 pytest-runner==2.8
-six==1.10.0
 amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+setuptools<=60.5.0
 py==1.10.0
-pytest>=6.1.1
-pytest-runner>=2.8
+pytest==6.1.1
+pytest-runner==2.8
 amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 py==1.10.0
 pytest>=6.1.1
-pytest-runner==2.8
+pytest-runner>=2.8
 amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-py>=1.10.0
-pytest>=6.1.1
-pytest-runner>=2.8
-six>=1.10.0
+py==1.10.0
+pytest==6.1.1
+pytest-runner==2.8
+six==1.10.0
 amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-py>=1.10.0
-pytest==6.1.1
+py==1.10.0
+pytest>=6.1.1
 pytest-runner==2.8
 amazon.ion==0.8.0
 docopt==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-setuptools<=60.5.0
 py==1.10.0
-pytest==6.1.1
-pytest-runner==2.8
+pytest==6.2.4
+pytest-runner==5.3.1
 amazon.ion==0.8.0
 docopt==0.6.2


### PR DESCRIPTION
Pending resolution of https://github.com/amazon-ion/ion-python/issues/218

*Issue #, if available:*

https://github.com/amazon-ion/ion-python/issues/218

*Description of changes:*

Temporary workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
