### PR TITLE
Updates ion-tests directory name for Ion 1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python }}
 
       - name: Create a virtual environment
-        run: python3 -m venv ./venv && . venv/bin/activate
+        run: python -m venv ./venv && . venv/bin/activate
 
       - run: pip install --upgrade setuptools
       - run: pip install --use-pep517 -r requirements.txt

--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -376,7 +376,7 @@ def test_type_from_str(name):
 
 def test_dir_from_version(version):
     if "1.0" == version:
-        return "iontestdata_1_0"
+        return "iontestdata"
     elif "1.1" == version:
         return "iontestdata_1_1"
     raise ValueError("Unknown Ion version: %s" % version)


### PR DESCRIPTION
*Description of changes:*

https://github.com/amazon-ion/ion-tests/pull/93 changed the name of the directory for the Ion 1.0 files back to `iontestdata`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
