### PR TITLE
Change default branch behavior to remove defaulting to 'master' branch.

### DIFF
--- a/amazon/iontest/ion_test_driver.py
+++ b/amazon/iontest/ion_test_driver.py
@@ -41,11 +41,12 @@ Options:
     -i, --implementation <description>  Test an additional implementation specified by a description of the form
                                         name,location,revision. Name must match one of the names returned by `--list`.
                                         Location may be a local path or a URL. Revision is optional, may be either a
-                                        branch name or commit hash, and defaults to `master`.
+                                        branch name or commit hash, and defaults to the repository's default branch.
 
     -I, --ion-tests <description>       Override the default ion-tests location by providing a description of the form
                                         location,revision. Location may be a local path or a URL. Revision is optional,
-                                        may be either a branch name or commit hash, and defaults to `master`.
+                                        may be either a branch name or commit hash, and defaults to the repository's
+                                        default branch.
 
     -l, --list                          List the implementations that can be built by this tool.
 
@@ -175,7 +176,10 @@ class IonResource:
             shutil.rmtree(tmp_dir_root)
 
     def install(self):
-        print('Installing %s revision %s.' % (self._name, self.__revision))
+        if self.__revision is None:
+            print('Installing %s default branch.' % (self._name, ))
+        else:
+            print('Installing %s revision %s.' % (self._name, self.__revision))
         self.__git_clone_revision()
         os.chdir(self._build_dir)
         self._build.install(self.__build_log)
@@ -744,7 +748,7 @@ def tokenize_description(description, has_name):
     if not has_name:
         max_components = 2
     if len(components) < max_components:
-        revision = 'master'
+        revision = None
     else:
         revision = components[max_components - 1]
     if len(components) < max_components - 1:

--- a/amazon/iontest/ion_test_driver_config.py
+++ b/amazon/iontest/ion_test_driver_config.py
@@ -71,8 +71,8 @@ ION_BUILDS = {
 # Ion implementations hosted in Github. Local implementations may be tested using the `--implementation` argument,
 # and should not be added here. For the proper description format, see the ion_test_driver CLI help.
 ION_IMPLEMENTATIONS = [
-    'ion-c,https://github.com/amazon-ion/ion-c.git,master',
-    'ion-java,https://github.com/amazon-ion/ion-java.git,master',
-    'ion-js,https://github.com/amazon-ion/ion-js.git,master'
+    'ion-c,https://github.com/amazon-ion/ion-c.git',
+    'ion-java,https://github.com/amazon-ion/ion-java.git',
+    'ion-js,https://github.com/amazon-ion/ion-js.git'
     # TODO add more Ion implementations here
 ]


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
Prior to this PR ion-test-driver would default to using `master` as the branch for cloned repositories. We have a mix now where some of our repositories have not migrated to using `main` over master, which has led to a few test failures when pulling `ion-tests` ([example](https://github.com/amazon-ion/ion-c/actions/runs/11739975454/job/32705593573#step:9:40)).

This PR changes ion-test-driver so that if a revision is not provided, rather than assuming the name of the active branch, ion-test-driver will leave the cloned version of the repo alone, defaulting to the repository's configured active branch.

The code already supported having a missing revision, so this PR ultimately just removes the defaulting to `master`, and removes the declared default revisions in the implementation list so that they do not have to stay in sync with the repositories.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
